### PR TITLE
style:center align footer logo

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -149,3 +149,13 @@ h1 {
   padding-top: 10px;
 }
 
+/* 
+By default, an <a> tag is an inline element, which can affect the alignment of
+its contents. To center the <a> tag (and thus the image inside it) within the flex container, 
+you can make the <a> tag a flex container as well and apply the same centering styles to it.
+*/
+.footer a {
+  display: flex;
+  justify-content: center;
+}
+

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       <button class="next-btn disabled">Next</button>
     </section>
     <footer class="footer">
-      <!--a href="http://www.iigmyanmar.com/index" target="_blank"--><img src="img/IIG-logo.png" alt="IIG Myanmar"><!--/a-->
+      <a href="http://www.iigmyanmar.com/index" target="_blank"><img src="img/IIG-logo.png" alt="IIG Myanmar"></a>
     </footer>
   </div>
   


### PR DESCRIPTION
Footer logo was left align when it is wrap with <a>; center align with flex.